### PR TITLE
correct quickstart document

### DIFF
--- a/doc/quickstart/index.md
+++ b/doc/quickstart/index.md
@@ -2,7 +2,7 @@
 
 Add [ScalaCSS](https://github.com/japgolly/scalacss/) to your project by adding this dependency to your SBT build:
 
-<pre><code class="lang-scala">libraryDependencies += <span class="hljs-string">&quot;com.github.japgolly.scalacss&quot;</span> %%% <span class="hljs-string">&quot;core&quot;</span> % <span class="hljs-string">&quot;{{ book.ver }}&quot;</span></code></pre>
+<pre><code class="lang-scala">libraryDependencies += <span class="hljs-string">&quot;com.github.japgolly.scalacss&quot;</span> %% <span class="hljs-string">&quot;core&quot;</span> % <span class="hljs-string">&quot;{{ book.ver }}&quot;</span></code></pre>
 
 Then to start using it, decide which of the following best suits your needs.
 
@@ -22,4 +22,3 @@ Like SCSS and LESS.
 Styles are values that can be applied directly in Scala & Scala.JS to HTML-like _stuff_.
 
 [Example.](inline.md)
-


### PR DESCRIPTION
libraryDependencies had 3 times "%", but it should be 2 times "%".

old : `libraryDependencies += "com.github.japgolly.scalacss" %%% "core" % "0.1.0"`
corrected : `libraryDependencies += "com.github.japgolly.scalacss" %% "core" % "0.1.0"`
