### PR TITLE
Add transform to display: flex properties.

### DIFF
--- a/core/src/main/scala/japgolly/scalacss/Attrs.scala
+++ b/core/src/main/scala/japgolly/scalacss/Attrs.scala
@@ -816,7 +816,8 @@ object Attrs {
    * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/display">MDN</a>
    */
   object display extends TypedAttrBase {
-    override val attr = Attr.real("display")
+    override val attr = Attr.real("display", 
+      Transform.values(CanIUse.flexbox)(L.flex, L.inlineFlex))
     @inline def block             = av(L.block)
     @inline def contents          = av(L.contents)
     @inline def flex              = av(L.flex)


### PR DESCRIPTION
display: flex/inline-flex need -webkit prefix to work on Safari.