### PR TITLE
allow multiple styles to be used as a modifier in scalatags

### DIFF
--- a/ext-scalatags/src/main/scala-js/scalacss/ScalatagsJsDom.scala
+++ b/ext-scalatags/src/main/scala-js/scalacss/ScalatagsJsDom.scala
@@ -6,8 +6,9 @@ import all._
 
 trait ScalatagsJsDomImplicits {
 
-  implicit final def styleaToJsDomTag(s: StyleA): Modifier =
-    cls := s.htmlClass
+  implicit def styleaToJsDomTag(s: scalacss.StyleA): Modifier = new Modifier {
+    def applyTo(t: org.scalajs.dom.Element) = t.classList.add(s.className.value)
+  }
 
   implicit final def styleJsDomTagRenderer(implicit s: Renderer[String]): Renderer[TypedTag[HTMLStyleElement]] =
     new ScalatagsJsDomRenderer(s)

--- a/ext-scalatags/src/main/scala/scalacss/ScalatagsText.scala
+++ b/ext-scalatags/src/main/scala/scalacss/ScalatagsText.scala
@@ -5,8 +5,9 @@ import all._
 
 trait ScalatagsTextImplicits {
 
-  implicit final def styleaToTextTag(s: StyleA): Modifier =
-    cls := s.htmlClass
+  implicit final def styleaToTextTag(s: StyleA): Modifier = new Modifier{
+    def applyTo(t: scalatags.text.Builder) = t.appendAttr("class", " " + s.className.value)
+  }
 
   implicit final def styleTextTagRenderer(implicit s: Renderer[String]): Renderer[TypedTag[String]] =
     new ScalatagsTextRenderer(s)

--- a/ext-scalatags/src/test/scala/scalacss/ScalatagsTest.scala
+++ b/ext-scalatags/src/test/scala/scalacss/ScalatagsTest.scala
@@ -15,6 +15,10 @@ object ScalatagsTest extends TestSuite {
       padding(0.3 ex, 2 ex)
     )
 
+    val other = style(
+      margin(1 ex)
+    )
+
     val bootstrappy = style(addClassName("btn btn-default"))
   }
 
@@ -30,19 +34,28 @@ object ScalatagsTest extends TestSuite {
                        |  padding: 0.3ex 2ex;
                        |}
                        |
+                       |.ScalatagsTest_MyStyles-other {
+                       |  margin: 1ex;
+                       |}
+                       |
                        |</style>""".stripMargin)
     }
 
     'simple {
       val el = input(`type` := "text", MyStyles.input, value := "ah")
       val html = el.toString()
-      assertEq(html, """<input type="text" class="ScalatagsTest_MyStyles-input" value="ah" />""")
+      assertEq(html, """<input type="text" class=" ScalatagsTest_MyStyles-input" value="ah" />""")
     }
 
     'addClassName {
       val el = button(MyStyles.bootstrappy)
       val html = el.toString()
-      assertEq(html, """<button class="btn btn-default"></button>""")
+      assertEq(html, """<button class=" btn btn-default"></button>""")
+    }
+    'multipleStyles {
+      val el = input(`type` := "text", MyStyles.input, MyStyles.other, value := "ah")
+      val html = el.toString()
+      assertEq(html, """<input type="text" class=" ScalatagsTest_MyStyles-input ScalatagsTest_MyStyles-other" value="ah" />""")
     }
 
   }


### PR DESCRIPTION
This improves the scalatags-ext modifier to allow for multiple styleAs to be applied to a scalatag tag. Using the cls := s.classname.value approach would simply overwrite the class of the final rendered element, basically allowing for only one such styleA to be used as a modifier. 