### PR TITLE
Add toString to styleA

### DIFF
--- a/core/src/main/scala/scalacss/package.scala
+++ b/core/src/main/scala/scalacss/package.scala
@@ -84,6 +84,8 @@ package object scalacss {
     /** Value to be applied to a HTML element's `class` attribute. */
     val htmlClass: String =
       (className.value /: addClassNames)(_ + " " + _.value)
+
+    override def toString = htmlClass
   }
 
   /** Faster than Vector(a) */


### PR DESCRIPTION
In libraries without scalacss integration I need to write something like this to use style:
```
someStyleClass.someStyle.htmlClass
```
If i want to use more than one style I'm writing this:
```
s"${someStyleClass.someStyle1.htmlClass} ${someStyleClass.someStyle2.htmlClass} 
```
With overrided `toString` method I will be able to use styles without annoying `.htmlClass`. 