### PR TITLE
Update ext-scalatags to support multiple styles

### DIFF
--- a/ext-scalatags/src/main/scala-js/scalacss/ScalatagsJsDom.scala
+++ b/ext-scalatags/src/main/scala-js/scalacss/ScalatagsJsDom.scala
@@ -6,8 +6,9 @@ import all._
 
 trait ScalatagsJsDomImplicits {
 
-  implicit final def styleaToJsDomTag(s: StyleA): Modifier =
-    cls := s.htmlClass
+  implicit final def styleaToJsDomTag(s: StyleA): Modifier = new Modifier {
+    def applyTo(t: dom.Element) = t.classList.add(s.htmlClass)
+  }
 
   implicit final def styleJsDomTagRenderer(implicit s: Renderer[String]): Renderer[TypedTag[HTMLStyleElement]] =
     new ScalatagsJsDomRenderer(s)

--- a/ext-scalatags/src/main/scala/scalacss/ScalatagsText.scala
+++ b/ext-scalatags/src/main/scala/scalacss/ScalatagsText.scala
@@ -5,8 +5,9 @@ import all._
 
 trait ScalatagsTextImplicits {
 
-  implicit final def styleaToTextTag(s: StyleA): Modifier =
-    cls := s.htmlClass
+  implicit final def styleaToTextTag(s: StyleA): new Modifier {
+    def applyTo(t: text.Builder) = t.appendAttr("class", " " + s.htmlClass)
+  }
 
   implicit final def styleTextTagRenderer(implicit s: Renderer[String]): Renderer[TypedTag[String]] =
     new ScalatagsTextRenderer(s)


### PR DESCRIPTION
Simple change based on the way scalatags implements their implicit to include scalatags.Cls in tags.
See ClsModifier in the following:
https://github.com/lihaoyi/scalatags/blob/ee7d3b8e352923f0a166814d6fdfbcccf5b6a44e/scalatags/shared/src/main/scala/scalatags/Text.scala
https://github.com/lihaoyi/scalatags/blob/ee7d3b8e352923f0a166814d6fdfbcccf5b6a44e/scalatags/js/src/main/scala/scalatags/JsDom.scala