### PR TITLE
ext-scalatags: Add support for multiple styles per element

### DIFF
--- a/ext-scalatags/src/main/scala-js/scalacss/ScalatagsJsDom.scala
+++ b/ext-scalatags/src/main/scala-js/scalacss/ScalatagsJsDom.scala
@@ -6,8 +6,9 @@ import all._
 
 trait ScalatagsJsDomImplicits {
 
-  implicit final def styleaToJsDomTag(s: StyleA): Modifier =
-    cls := s.htmlClass
+  implicit final def styleaToJsDomTag(s: StyleA): Modifier = new Modifier {
+    def applyTo(t: dom.Element) = t.classList.add(s.htmlClass)
+  }
 
   implicit final def styleJsDomTagRenderer(implicit s: Renderer[String]): Renderer[TypedTag[HTMLStyleElement]] =
     new ScalatagsJsDomRenderer(s)

--- a/ext-scalatags/src/main/scala-js/scalacss/ScalatagsJsDom.scala
+++ b/ext-scalatags/src/main/scala-js/scalacss/ScalatagsJsDom.scala
@@ -1,5 +1,6 @@
 package scalacss
 
+import org.scalajs.dom
 import org.scalajs.dom.raw.HTMLStyleElement
 import scalatags.JsDom._
 import all._

--- a/ext-scalatags/src/main/scala/scalacss/ScalatagsText.scala
+++ b/ext-scalatags/src/main/scala/scalacss/ScalatagsText.scala
@@ -1,11 +1,12 @@
 package scalacss
 
 import scalatags.Text._
+import scalatags.text
 import all._
 
 trait ScalatagsTextImplicits {
 
-  implicit final def styleaToTextTag(s: StyleA): new Modifier {
+  implicit final def styleaToTextTag(s: StyleA): Modifier = new Modifier {
     def applyTo(t: text.Builder) = t.appendAttr("class", " " + s.htmlClass)
   }
 

--- a/ext-scalatags/src/main/scala/scalacss/ScalatagsText.scala
+++ b/ext-scalatags/src/main/scala/scalacss/ScalatagsText.scala
@@ -5,8 +5,9 @@ import all._
 
 trait ScalatagsTextImplicits {
 
-  implicit final def styleaToTextTag(s: StyleA): Modifier =
-    cls := s.htmlClass
+  implicit final def styleaToTextTag(s: StyleA): new Modifier {
+    def applyTo(t: text.Builder) = t.appendAttr("class", " " + s.htmlClass)
+  }
 
   implicit final def styleTextTagRenderer(implicit s: Renderer[String]): Renderer[TypedTag[String]] =
     new ScalatagsTextRenderer(s)

--- a/ext-scalatags/src/test/scala/scalacss/ScalatagsTest.scala
+++ b/ext-scalatags/src/test/scala/scalacss/ScalatagsTest.scala
@@ -34,25 +34,29 @@ object ScalatagsTest extends TestSuite {
                        |  padding: 0.3ex 2ex;
                        |}
                        |
+                       |.ScalatagsTest_MyStyles-required {
+                       |  border: thin solid red;
+                       |}
+                       |
                        |</style>""".stripMargin)
     }
 
     'simple {
       val el = input(`type` := "text", MyStyles.input, value := "ah")
       val html = el.toString()
-      assertEq(html, """<input type="text" class="ScalatagsTest_MyStyles-input" value="ah" />""")
+      assertEq(html, """<input type="text" class=" ScalatagsTest_MyStyles-input" value="ah" />""")
     }
 
     'addClassName {
       val el = button(MyStyles.bootstrappy)
       val html = el.toString()
-      assertEq(html, """<button class="btn btn-default"></button>""")
+      assertEq(html, """<button class=" btn btn-default"></button>""")
     }
 
     'multipleStyles {
       val el = input(`type` := "text", MyStyles.input, MyStyles.required, value := "ah")
       val html = el.toString()
-      assertEq(html, """<input type="text" class="ScalatagsTest_MyStyles-input ScalatagsTest_MyStyles-required" value="ah" />""")
+      assertEq(html, """<input type="text" class=" ScalatagsTest_MyStyles-input ScalatagsTest_MyStyles-required" value="ah" />""")
     }
   }
 }

--- a/ext-scalatags/src/test/scala/scalacss/ScalatagsTest.scala
+++ b/ext-scalatags/src/test/scala/scalacss/ScalatagsTest.scala
@@ -15,6 +15,10 @@ object ScalatagsTest extends TestSuite {
       padding(0.3 ex, 2 ex)
     )
 
+    val required = style(
+      border(thin, solid, red)
+    )
+
     val bootstrappy = style(addClassName("btn btn-default"))
   }
 
@@ -45,5 +49,10 @@ object ScalatagsTest extends TestSuite {
       assertEq(html, """<button class="btn btn-default"></button>""")
     }
 
+    'multipleStyles {
+      val el = input(`type` := "text", MyStyles.input, MyStyles.required, value := "ah")
+      val html = el.toString()
+      assertEq(html, """<input type="text" class="ScalatagsTest_MyStyles-input ScalatagsTest_MyStyles-required" value="ah" />""")
+    }
   }
 }


### PR DESCRIPTION
Based on scalatags' own Cls to Modifier implicit conversion.