### PR TITLE
Add each class name to the DOM individually, to prevent InvalidCharacterErrors

### DIFF
--- a/ext-scalatags/src/main/scala-js/scalacss/ScalatagsJsDom.scala
+++ b/ext-scalatags/src/main/scala-js/scalacss/ScalatagsJsDom.scala
@@ -8,7 +8,7 @@ import all._
 trait ScalatagsJsDomImplicits {
 
   implicit final def styleaToJsDomTag(s: StyleA): Modifier = new Modifier {
-    def applyTo(t: dom.Element) = t.classList.add(s.htmlClass)
+    def applyTo(t: dom.Element) = s.htmlClass.split(' ').foreach(cn => t.classList.add(cn))
   }
 
   implicit final def styleJsDomTagRenderer(implicit s: Renderer[String]): Renderer[TypedTag[HTMLStyleElement]] =


### PR DESCRIPTION
As I mentioned on gitter, I was seeing errors when adding multiple class names to scalatags elements:

> Uncaught InvalidCharacterError: Failed to execute 'add' on 'DOMTokenList': The token provided ('btn btn-danger') contains HTML space characters, which are not valid in tokens.

This seems to fix it.