### PR TITLE
Fix for test links on the documentation

### DIFF
--- a/doc/features/basics.md
+++ b/doc/features/basics.md
@@ -60,5 +60,5 @@ To create a style module,
 
 ##### Full examples:
 
-* [StandaloneTest.scala](https://github.com/japgolly/scalacss/blob/master/core/src/test/scala/scalacss/full/StandaloneTest.scala)
-* [InlineTest.scala](https://github.com/japgolly/scalacss/blob/master/core/src/test/scala/scalacss/full/InlineTest.scala)
+* [StandaloneTest.scala](https://github.com/japgolly/scalacss/blob/master/core/shared/src/test/scala/scalacss/full/StandaloneTest.scala)
+* [InlineTest.scala](https://github.com/japgolly/scalacss/blob/master/core/shared/src/test/scala/scalacss/full/InlineTest.scala)


### PR DESCRIPTION
I found a couple of broken links on scalacss docbook, here is the fix