### PR TITLE
`addClassName` example in docs fixed

### DIFF
--- a/doc/ext/scalatags.md
+++ b/doc/ext/scalatags.md
@@ -36,7 +36,7 @@ object MyStyles extends StyleSheet.Inline {
   import dsl._
 
   val bootstrapButton = style(
-    addClassName("btn btn-default"),
+    addClassNames("btn", "btn-default"),
     fontSize(200 %%)
   )
 }


### PR DESCRIPTION
addClassName with multiple classnames in the documentation example for scalatags leads to

```
app-fastopt.js:15262Uncaught DOMException: Failed to execute 'add' on 'DOMTokenList': The token provided ('btn btn-primary') contains HTML space characters, which are not valid in tokens.
```

Fixed with `addClassNames`