### PR TITLE
TypedValue for background-clip

### DIFF
--- a/core/shared/src/main/scala/scalacss/internal/Attrs.scala
+++ b/core/shared/src/main/scala/scalacss/internal/Attrs.scala
@@ -226,7 +226,21 @@ object Attrs {
    *
    * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/background-clip">MDN</a>
    */
-  final def backgroundClip = Attr.real("background-clip")
+  object backgroundClip extends TypedAttrBase with BackgroundClipDecorationOps {
+    override val attr = Attr.real("background-clip", Transform keys CanIUse.backgroundImgOpts)
+
+    override protected def next(v: Value): Accum = new Accum(v)
+    final class Accum(v: Value) extends ToAV with BackgroundClipDecorationOps {
+      override def av: AV = AV(attr, v)
+      override protected def next(v: Value): Accum = new Accum(s"${this.v} $v")
+    }
+  }
+  trait BackgroundClipDecorationOps {
+    protected def next(v: Value): backgroundClip.Accum
+    final def contentBox: backgroundClip.Accum = next(Literal.contentBox)
+    final def paddingBox: backgroundClip.Accum = next(Literal.paddingBox)
+    final def borderBox: backgroundClip.Accum = next(Literal.borderBox)
+  }
 
   /**
    * The background-color CSS property sets the background color of an element, either through a color value or the keyword transparent.

--- a/core/shared/src/test/scala/scalacss/internal/AttrTest.scala
+++ b/core/shared/src/test/scala/scalacss/internal/AttrTest.scala
@@ -8,6 +8,7 @@ import scalacss.test.TestUtil._
 import AttrCmp.{Overlap, Unrelated}
 import Attrs._
 import ValueT.Rules._
+import Dsl.ToAVToAV
 
 object AttrTest extends TestSuite {
 
@@ -88,8 +89,16 @@ object AttrTest extends TestSuite {
       test(textIndent(length, hanging, eachLine), "3px hanging each-line")
     }
 
+    'backgroundClip {
+      def test(av: AV, exp: String): Unit = assertEq(av.value, exp)
+      test(backgroundClip.paddingBox                        , "padding-box")
+      test(backgroundClip.borderBox                         , "border-box")
+      test(backgroundClip.contentBox                        , "content-box")
+      test(backgroundClip.contentBox.paddingBox             , "content-box padding-box")
+      test(backgroundClip.contentBox.paddingBox.av.important, "content-box padding-box !important")
+    }
+
     'borderRadius{
-      implicit def ToAVToAV(x: ToAV): AV = x.av
       def test(av: AV, exp: String): Unit = assertEq(av.value, exp)
       test(borderRadius(px(3)), "3px")
       test(borderRadius(px(3))(px(5)), "3px / 5px")


### PR DESCRIPTION
Here is a `TypedValue` for the `background-clip` attribute. This is my first attempt at a `TypedValue` but works fine in my project