### PR TITLE
fontFamily(): allow string value for font-family attribute

### DIFF
--- a/core/shared/src/main/scala/scalacss/internal/Attrs.scala
+++ b/core/shared/src/main/scala/scalacss/internal/Attrs.scala
@@ -1011,7 +1011,8 @@ object Attrs {
    */
   object fontFamily extends TypedAttrBase {
     override val attr = Attr.real("font-family")
-    def apply(a: FontFace[String]): AV = av(a.fontFamily)
+    def apply(a: FontFace[String]): AV = apply(a.fontFamily)
+    def apply(familyName: String): AV = av(familyName)
   }
 
   /**

--- a/core/shared/src/test/scala/scalacss/full/InlineTest.scala
+++ b/core/shared/src/test/scala/scalacss/full/InlineTest.scala
@@ -267,6 +267,18 @@ object MyInlineWithFontFace extends StyleSheet.Inline {
   val myFontText3 = style(fontFamily(ff6))
 }
 
+object MyInlineWithRawFontFamily extends StyleSheet.Inline {
+  import dsl._
+
+  val myFont1 = style( fontFamily("verdana") )
+  val myFont2 = style( fontFamily("comic-sans") )
+  val myFont3 = style(
+    fontFamily("times-new-roman"),
+    backgroundColor( Color("#ffff00") )
+  )
+}
+
+
 object InlineTest extends utest.TestSuite {
   import utest._
   import scalacss.test.TestUtil._
@@ -678,5 +690,22 @@ object InlineTest extends utest.TestSuite {
          |  font-family: MyInlineWithFontFace-0002;
          |}
        """.stripMargin))
+
+    'fontFamilies - assertMultiline( norm(MyInlineWithRawFontFamily.render), norm(
+      """
+        |.MyInlineWithRawFontFamily-myFont1 {
+        |  font-family: verdana;
+        |}
+        |
+        |.MyInlineWithRawFontFamily-myFont2 {
+        |  font-family: comic-sans;
+        |}
+        |
+        |.MyInlineWithRawFontFamily-myFont3 {
+        |  font-family: times-new-roman;
+        |  background-color: #ffff00;
+        |}
+      """.stripMargin))
+
   }
 }


### PR DESCRIPTION
Currently, it is not possible to use font-faces from external CSS-files:
`fontFamily.apply()` allow only `FontFace` instances.

This commit allows to specify raw `font-family` string value, making possible to use non-inline fonts faces.