### PR TITLE
Make steps TimingFunctionDirection default to TimingFunctionDirection.end

### DIFF
--- a/core/shared/src/main/scala/scalacss/internal/Attrs.scala
+++ b/core/shared/src/main/scala/scalacss/internal/Attrs.scala
@@ -185,15 +185,15 @@ object Attrs {
    */
   object animationTimingFunction extends TypedAttrBase {
     override val attr: Attr = Attr.real("animation-timing-function", Transform keys CanIUse.animation)
-    def cubicBezier(x1: Double, y1: Double, x2: Double, y2: Double) = avl(new LT.cubicBezier(x1, y1, x2, y2))
-    def steps(steps: Int, direction: LT.TimingFunctionDirection)    = avl(new LT.steps(steps, direction))
-    def linear                                                      = avl(LT.linear)
-    def ease                                                        = avl(LT.ease)
-    def easeIn                                                      = avl(LT.easeIn)
-    def easeInOut                                                   = avl(LT.easeInOut)
-    def easeOut                                                     = avl(LT.easeOut)
-    def stepStart                                                   = avl(LT.stepStart)
-    def stepEnd                                                     = avl(LT.stepEnd)
+    def cubicBezier(x1: Double, y1: Double, x2: Double, y2: Double)       = avl(new LT.cubicBezier(x1, y1, x2, y2))
+    def steps(steps: Int, direction: LT.TimingFunctionDirection = LT.end) = avl(new LT.steps(steps, direction))
+    def linear                                                            = avl(LT.linear)
+    def ease                                                              = avl(LT.ease)
+    def easeIn                                                            = avl(LT.easeIn)
+    def easeInOut                                                         = avl(LT.easeInOut)
+    def easeOut                                                           = avl(LT.easeOut)
+    def stepStart                                                         = avl(LT.stepStart)
+    def stepEnd                                                           = avl(LT.stepEnd)
   }
 
   /**
@@ -2185,15 +2185,15 @@ object Attrs {
    */
   object transitionTimingFunction extends TypedAttrBase {
     override val attr: Attr = Attr.real("transition-timing-function", Transform keys CanIUse.transitions)
-    def cubicBezier(x1: Double, y1: Double, x2: Double, y2: Double)   = avl(new LT.cubicBezier(x1, y1, x2, y2))
-    def steps(steps: Int, direction: LT.TimingFunctionDirection)      = avl(new LT.steps(steps, direction))
-    def linear                                                        = avl(LT.linear)
-    def ease                                                          = avl(LT.ease)
-    def easeIn                                                        = avl(LT.easeIn)
-    def easeInOut                                                     = avl(LT.easeInOut)
-    def easeOut                                                       = avl(LT.easeOut)
-    def stepStart                                                     = avl(LT.stepStart)
-    def stepEnd                                                       = avl(LT.stepEnd)
+    def cubicBezier(x1: Double, y1: Double, x2: Double, y2: Double)       = avl(new LT.cubicBezier(x1, y1, x2, y2))
+    def steps(steps: Int, direction: LT.TimingFunctionDirection = LT.end) = avl(new LT.steps(steps, direction))
+    def linear                                                            = avl(LT.linear)
+    def ease                                                              = avl(LT.ease)
+    def easeIn                                                            = avl(LT.easeIn)
+    def easeInOut                                                         = avl(LT.easeInOut)
+    def easeOut                                                           = avl(LT.easeOut)
+    def stepStart                                                         = avl(LT.stepStart)
+    def stepEnd                                                           = avl(LT.stepEnd)
   }
 
   /**

--- a/core/shared/src/main/scala/scalacss/internal/Values.scala
+++ b/core/shared/src/main/scala/scalacss/internal/Values.scala
@@ -35,7 +35,7 @@ trait TypedLiteralAliases {
   final def start                                                           = Typed.start
   final def end                                                             = Typed.end
   final def cubicBezier(x1: Double, y1: Double, x2: Double, y2: Double)     = new Typed.cubicBezier(x1, y1, x2, y2)
-  final def steps(steps: Int, direction: TimingFunctionDirection)           = new Typed.steps(steps, direction)
+  final def steps(steps: Int, direction: TimingFunctionDirection = end)     = new Typed.steps(steps, direction)
   final def linear                                                          = Typed.linear
   final def ease                                                            = Typed.ease
   final def easeIn                                                          = Typed.easeIn


### PR DESCRIPTION
The animation-timing-function direction on steps(steps, direction) is optional and if unspecified defaults to end.

This change allows users to write
``` scala
animationTimingFunction.steps(2)
```
rather than
``` scala
animationTimingFunction.steps(2, end)
```