### PR TITLE
Fixed naming issue for more than 26 registered StyleSheet.Inline

### DIFF
--- a/core/shared/src/main/scala/scalacss/internal/mutable/Register.scala
+++ b/core/shared/src/main/scala/scalacss/internal/mutable/Register.scala
@@ -250,9 +250,17 @@ object Register { // ===========================================================
     private[this] var _nextShortPrefix = 0
 
     def nextShortPrefix(): String = {
-      val p = ('a' + _nextShortPrefix).toChar.toString
+      val p = toAlphabet(_nextShortPrefix)
       _nextShortPrefix += 1
       p
+    }
+
+    private[this] def toAlphabet(i: Int): String = {
+      val quot = i / 26
+      val rem = i % 26
+      val letter = ('a' + rem).toChar
+      if (quot == 0) letter.toString
+      else toAlphabet(quot - 1) + letter
     }
 
     def short(prefix  : String      = "_",
@@ -266,6 +274,8 @@ object Register { // ===========================================================
 
     def short8: NameGen =
       short("\u00a2", alphabet = nmchar8)
+
+    private[mutable] def resetNextShortPrefix() = _nextShortPrefix = 0
   }
 
   // ===================================================================================================================

--- a/core/shared/src/test/scala/scalacss/internal/mutable/NameGenTest.scala
+++ b/core/shared/src/test/scala/scalacss/internal/mutable/NameGenTest.scala
@@ -1,0 +1,26 @@
+package scalacss.internal.mutable
+
+import utest._
+
+import scalacss.internal.ClassNameHint
+import scalacss.internal.mutable.Register.NameGen
+import scalacss.test.TestUtil._
+
+object NameGenTest extends TestSuite {
+
+  override val tests = TestSuite {
+    'nameGenUniqueAndAscii {
+      println((1 to 1000).map(_ => NameGen.short().next(ClassNameHint("placeholder"))._1.value))
+
+      val classesAmount = 1000
+      val classNames = (1 to classesAmount).map(_ => NameGen.short().next(ClassNameHint("placeholder"))._1.value)
+      val uniqueClassNames = classNames.toSet
+
+
+      assertEq(uniqueClassNames.size, classesAmount)
+      assertEq(uniqueClassNames.count(_.matches("^[a-z0-9_]+$")), classesAmount)
+
+      NameGen.resetNextShortPrefix()
+    }
+  }
+}

--- a/core/shared/src/test/scala/scalacss/internal/mutable/NameGenTest.scala
+++ b/core/shared/src/test/scala/scalacss/internal/mutable/NameGenTest.scala
@@ -10,12 +10,9 @@ object NameGenTest extends TestSuite {
 
   override val tests = TestSuite {
     'nameGenUniqueAndAscii {
-      println((1 to 1000).map(_ => NameGen.short().next(ClassNameHint("placeholder"))._1.value))
-
       val classesAmount = 1000
       val classNames = (1 to classesAmount).map(_ => NameGen.short().next(ClassNameHint("placeholder"))._1.value)
       val uniqueClassNames = classNames.toSet
-
 
       assertEq(uniqueClassNames.size, classesAmount)
       assertEq(uniqueClassNames.count(_.matches("^[a-z0-9_]+$")), classesAmount)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.16


### PR DESCRIPTION
As discussed in https://github.com/japgolly/scalacss/issues/122

I've also updated sbt (0.13.13 -> 0.13.16)

There's one ugly side to this PR. The object NameGen makes testing a bit tricky as the prefixes are accumulated between tests, e.g. scalacss.full.DefaultsTest started failing as it wasn't getting it's expected _a0 class names but higher ones (which are not really predictable as it's depending on what other tests are doing). This issue is nothing new, guess the random test ordering was just in our favour so far... I didn't see a fast and clean way to solve this so I've just put in are reset function for the counter. Hope thats good enough for now.