### PR TITLE
Support text overflow

### DIFF
--- a/core/shared/src/main/scala/scalacss/internal/Attrs.scala
+++ b/core/shared/src/main/scala/scalacss/internal/Attrs.scala
@@ -2164,7 +2164,12 @@ object Attrs {
    *
    * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow">MDN</a>
    */
-  final def textOverflow = Attr.real("text-overflow", Transform keys CanIUse.textOverflow)
+  object textOverflow extends TypedAttrBase {
+    override val attr = Attr.real("text-overflow")
+    def ellipsis           = av(L.ellipsis)
+    def clip               = av(L.clip)
+    def fade               = av(L.fade)
+  }
 
   /**
    * The text-rendering CSS property provides information to the rendering engine about what to optimize for when rendering text. The browser makes trade-offs among speed, legibility, and geometric precision. The text-rendering property is an SVG property that is not defined in any CSS standard. However, Gecko and WebKit browsers let you apply this property to HTML and XML content on Windows, Mac OS X and Linux.

--- a/core/shared/src/main/scala/scalacss/internal/Values.scala
+++ b/core/shared/src/main/scala/scalacss/internal/Values.scala
@@ -185,6 +185,7 @@ object Literal extends TypedLiteralAliases {
   def expanded           : Value = "expanded"
   def extraCondensed     : Value = "extra-condensed"
   def extraExpanded      : Value = "extra-expanded"
+  def fade               : Value = "fade"
   def fill               : Value = "fill"
   def fillAvailable      : Value = "fill-available"
   def firstBaseline      : Value = "first baseline"

--- a/core/shared/src/test/scala/scalacss/internal/AttrTest.scala
+++ b/core/shared/src/test/scala/scalacss/internal/AttrTest.scala
@@ -159,6 +159,7 @@ object AttrTest extends TestSuite {
       test(gridTemplateAreas("a b"), """ "a b" """)
       test(gridTemplateAreas("a b", "c d"), """ "a b" "c d" """)
     }
+
     'pointerEvents {
       def test(av: AV, exp: String): Unit = assertEq(av.value, exp.trim)
       test(pointerEvents.auto,    "auto")
@@ -167,6 +168,7 @@ object AttrTest extends TestSuite {
       test(pointerEvents.initial, "initial")
       test(pointerEvents.unset,   "unset")
     }
+
     'justifyContent {
       def test(av: AV, exp: String): Unit = assertEq(av.value, exp.trim)
       test(justifyContent.center       , "center")
@@ -188,6 +190,13 @@ object AttrTest extends TestSuite {
       test(justifyContent.inherit      , "inherit")
       test(justifyContent.initial      , "initial")
       test(justifyContent.unset        , "unset")
+    }
+
+    'textOverflow {
+      def test(av: AV, exp: String): Unit = assertEq(av.value, exp)
+      test(textOverflow.ellipsis                    , "ellipsis")
+      test(textOverflow.clip                        , "clip")
+      test(textOverflow.fade                        , "fade")
     }
   }
 }

--- a/doc/history/0.5.md
+++ b/doc/history/0.5.md
@@ -106,6 +106,7 @@
 # 0.5.6
 * New CSS attributes:
   * `pointer-events`
+  * `text-overflow`
 * New CSS values:
   * `justify-content: start|end|left|right|baseline|first baseline|last baseline|space-evenly|stretch|safe center|unsafe center`
 


### PR DESCRIPTION
This adds partial support for `text-overflow`. There are more cases I'd like to support but I wasn't able to get them to work. 

Support having arbitrary text
`textOverflow("text")`

Have values repeated like
`textOverflow.ellipsis.ellipsis`

If you can give me some indications on how to proceed to get those I may try to update this PR