### PR TITLE
Update ScalaJsReact, ScalaJS + Fix deprecation + test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 .idea*
 projectFilesBackup*
 target
-
+node_modules
 doc/_book
 
 project/sjsincoptbench.sbt

--- a/bench/big/src/demo/Main.scala
+++ b/bench/big/src/demo/Main.scala
@@ -3,9 +3,9 @@ package demo
 import scala.scalajs.js.JSApp
 import CssSettings._
 
-object Main extends JSApp {
+object Main {
 
-  override def main(): Unit = {
+  def main(args: Array[String]): Unit = {
     Styles.addToDocument()
     println(Styles.blahtable.colp.className)
   }

--- a/bench/react-with/src/demo.scala
+++ b/bench/react-with/src/demo.scala
@@ -16,9 +16,9 @@ object MyStyles extends StyleSheet.Inline {
     margin(12 px))
 }
 
-object Demo extends JSApp {
+object Demo {
 
-  override def main(): Unit = {
+  def main(args: Array[String]): Unit = {
     MyStyles.addToDocument()
     TodoApp().renderIntoDOM(document getElementById "todo")
     console.log("hello")

--- a/bench/react-without/src/demo.scala
+++ b/bench/react-without/src/demo.scala
@@ -2,9 +2,9 @@ import org.scalajs.dom.{console, document}
 import scala.scalajs.js.JSApp
 import japgolly.scalajs.react._, vdom.html_<^._, ScalazReact._
 
-object Demo extends JSApp {
+object Demo {
 
-  override def main(): Unit = {
+  def main(args: Array[String]): Unit = {
     TodoApp().renderIntoDOM(document getElementById "todo")
     console.log("hello")
   }

--- a/project/Bench.scala
+++ b/project/Bench.scala
@@ -5,6 +5,7 @@ import ScalaJSPlugin.autoImport._
 import ScalaJSPluginInternal.stageKeys
 import Lib._
 import ScalaCssBuild._
+import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object BenchBuild {
 
@@ -16,6 +17,7 @@ object BenchBuild {
   private def benchModuleJS(name: String, dir: File => File): Project =
     benchModule("bench-" + name, dir)
       .configure(commonSettings.js)
+      .settings(scalaJSUseMainModuleInitializer := true)
       .enablePlugins(ScalaJSPlugin)
 
   lazy val bench =

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -4,6 +4,7 @@ import com.typesafe.sbt.pgp.PgpKeys
 import sbtrelease.ReleasePlugin.autoImport._
 import xerial.sbt.Sonatype.autoImport._
 import Lib._
+import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object ScalaCssBuild {
 
@@ -19,7 +20,7 @@ object ScalaCssBuild {
     final val Scala211      = "2.11.11"
     final val Scala212      = "2.12.4"
     final val ScalaJsDom    = "0.9.4"
-    final val ScalaJsReact  = "1.1.1"
+    final val ScalaJsReact  = "1.3.1"
     final val Scalatags     = "0.6.7"
     final val Scalaz        = "7.2.18"
     final val UnivEq        = "1.0.2"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js"      % "sbt-scalajs"  % "0.6.19")
+addSbtPlugin("org.scala-js"      % "sbt-scalajs"  % "0.6.26")
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"      % "1.1.0")
 addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "2.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release"  % "1.0.7")


### PR DESCRIPTION
- Fix error in test by upgrading scalajs version (some jsdom error)
- Fix deprecation using `JsApp`
- Bump ScalaJs react version

FYI, `crossProject` is deprecated after this update. Need to use https://github.com/portable-scala/sbt-crossproject. But, I'll leave that open as another issue.